### PR TITLE
chore(deps): bump the github-actions group with 4 updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           go-version: '^1.18'
       - name: Run Golang CI Lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v6
         with:
           version: latest
           args: -E gofmt

--- a/.github/workflows/citk.yml
+++ b/.github/workflows/citk.yml
@@ -10,11 +10,11 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Setup Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version: "^1.18"
       - name: Checkout branch

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -6,7 +6,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v4
+      - uses: actions/stale@v9
         with:
           stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
           close-issue-message: 'This issue was closed because it has been stalled for 7 days with no activity.'


### PR DESCRIPTION
### Description

In this pull request, the following changes have been made:

- Update the GolangCI-Lint Action from version v3 to v6 in the .github/workflows/ci.yml file.
- Update the Actions/Checkout Action from version v3 to v4 and Actions/Setup-Go from version v3 to v5 in the .github/workflows/citk.yml file.
- Update the Actions/Stale Action from version v4 to v9 in the .github/workflows/stale.yml file.

These changes involve updating the versions of third-party GitHub Actions used in the workflows to newer versions.

- Update GolangCI-Lint Action version from v3 to v6 in .github/workflows/ci.yml
- Update Actions/Checkout Action version from v3 to v4 and Actions/Setup-Go Action version from v3 to v5 in .github/workflows/citk.yml
- Update Actions/Stale Action version from v4 to v9 in .github/workflows/stale.yml